### PR TITLE
Add 'defmt' feature to propagate stm32h7xx-hal defmt feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ targets = [ "thumbv7em-none-eabihf" ]
 [features]
 default = []
 ethernet = [ "stm32h7xx-hal/ethernet", "smoltcp" ]
+defmt = [ "stm32h7xx-hal/defmt" ]
 button-1-pa0 = []  # SB81=on, SB82=off
 led-1-pa5 = []     # SB65=on, SB54=off
 log-semihosting = [ "cortex-m-semihosting" ]


### PR DESCRIPTION
Title sums it up, I wanted to `demft::debug!` an I2C error but compiler complained `defmt::Format` wasn't implemented for `nucleo_h7xx::stm32h7xx_hal::i2c::Error`. This kept happening even after I manually pulled in `stm32h7xx_hal` with the `defmt` feature in my project.

With this PR you can now specify `nucleo-h7xx = { version = "0.2.1", features = ["defmt"] }` in your project's dependencies to get `defmt` formatting for the stm32's hal crate.