### PR TITLE
fix for issue #114447 <https://github.com/rust-lang/rust/issues/114447>

### DIFF
--- a/examples/ethernet_hal.rs
+++ b/examples/ethernet_hal.rs
@@ -119,7 +119,7 @@ fn main() -> ! {
             dp.ETHERNET_MAC,
             dp.ETHERNET_MTL,
             dp.ETHERNET_DMA,
-            &mut ETHERNET_DESCRIPTOR_RING,
+            &mut *core::ptr::addr_of_mut!(ETHERNET_DESCRIPTOR_RING),
             mac_addr.clone(),
             ccdr.peripheral.ETH1MAC,
             &ccdr.clocks,

--- a/src/ethernet.rs
+++ b/src/ethernet.rs
@@ -187,7 +187,7 @@ impl<'a> EthernetInterface<'a> {
 
         let mut interface = EthernetInterface::new(pins);
         let timeout_timer = match interface.up(
-            unsafe { &mut ETHERNET_STORAGE },
+            unsafe { &mut *core::ptr::addr_of_mut!(ETHERNET_STORAGE) },
             mac_address,
             ip_address,
             eth1mac,
@@ -248,7 +248,7 @@ impl<'a> EthernetInterface<'a> {
                 dp.ETHERNET_MAC,
                 dp.ETHERNET_MTL,
                 dp.ETHERNET_DMA,
-                &mut ETHERNET_DESCRIPTOR_RING,
+                &mut *core::ptr::addr_of_mut!(ETHERNET_DESCRIPTOR_RING),
                 ethernet_address,
                 eth1mac,
                 ccdr_clocks,


### PR DESCRIPTION
Building the ethernet example fails with `error: creating a mutable reference to mutable static is discouraged`.
Applied the suggestion by the compiler.

Tested with rustc 1.77.2 on a NUCLEO-H745ZI-Q board.