### PR TITLE
fix for #[warn(static_mut_refs)]

### DIFF
--- a/examples/ethernet_hal.rs
+++ b/examples/ethernet_hal.rs
@@ -141,12 +141,12 @@ fn main() -> ! {
 
     // create global static ETHERNET object
     unsafe {
-        ETHERNET = Some(Net::new(&mut ETHERNET_STORAGE, eth_dma, mac_addr));
+        ETHERNET = Some(Net::new(&mut *core::ptr::addr_of_mut!(ETHERNET_STORAGE), eth_dma, mac_addr));
     }
 
     // - udp socket -----------------------------------------------------------
 
-    let store = unsafe { &mut ETHERNET_STORAGE };
+    let store = unsafe { &mut *core::ptr::addr_of_mut!(ETHERNET_STORAGE) };
     let udp_rx_buffer = UdpSocketBuffer::new(
         &mut store.udp_rx_metadata[..],
         &mut store.udp_rx_buffer_storage[..],


### PR DESCRIPTION
Building the ethernet_hal example emits warnings triggered by the #[warn(static_mut_refs)] lint attribute.
Applied the suggestion by the compiler.

Tested with rustc 1.77.2 on a NUCLEO-H745ZI-Q board.